### PR TITLE
dereference before NULL check

### DIFF
--- a/tools/output.c
+++ b/tools/output.c
@@ -290,10 +290,11 @@ void
 sexp_put_digest(struct sexp_output *output)
 {
   TMP_DECL(digest, uint8_t, NETTLE_MAX_HASH_DIGEST_SIZE);
-  TMP_ALLOC(digest, output->hash->digest_size);
   
   assert(output->hash);
-
+  
+  TMP_ALLOC(digest, output->hash->digest_size);
+  
   output->hash->digest(output->ctx, output->hash->digest_size, digest);
 
   sexp_put_code_start(output, &nettle_base16);


### PR DESCRIPTION
In tools/output.c
Pointer 'output->hash' which was dereferenced at #302 is compared to NULL value at #304.

If output->hash is NULL then derefrencing it tries to read data from invalid location. Running program with NULL pointer will crash the system.

Solution:
Check output->hash for NULL value before dereferencing it.
place assert(output->hash); before TEMP_ALLOC at #302.